### PR TITLE
Just use the v1 sdk call to aws signers

### DIFF
--- a/lib/faraday_middleware/request/aws_signers_v4.rb
+++ b/lib/faraday_middleware/request/aws_signers_v4.rb
@@ -100,11 +100,7 @@ class FaradayMiddleware::AwsSignersV4 < Faraday::Middleware
   end
 
   def sign_request(req, credentials, service_name, region)
-    if defined?(Aws)
-      Aws::Signers::V4.new(credentials, service_name, region).sign(req)
-    else
-      AWS::Core::Signers::Version4.new(credentials, service_name, region).sign_request(req)
-    end
+    AWS::Core::Signers::Version4.new(credentials, service_name, region).sign_request(req)
   end
 
 end


### PR DESCRIPTION
We have introduced the 'Aws' namespace into the app but don't have the new signers. 

This will fix the elastic search bug